### PR TITLE
[DEVEX-50] Update this repository prefix on Azure resources

### DIFF
--- a/infra/identity/prod/westeurope/locals.tf
+++ b/infra/identity/prod/westeurope/locals.tf
@@ -1,8 +1,7 @@
 locals {
-  prefix    = "dx"
+  prefix    = "dxt"
   env_short = "p"
   env       = "prod"
-  domain    = "typescript"
   location  = "westeurope"
   project   = "${local.prefix}-${local.env_short}"
 
@@ -13,6 +12,6 @@ locals {
     CreatedBy   = "Terraform"
     Environment = "Prod"
     Owner       = "DevEx"
-    Source      = "https://github.com/pagopa/dx-typescript"
+    Source      = "https://github.com/pagopa/dx-typescript/blob/main/infra/identity/prod/westeurope"
   }
 }

--- a/infra/identity/prod/westeurope/main.tf
+++ b/infra/identity/prod/westeurope/main.tf
@@ -32,7 +32,6 @@ module "federated_identities" {
   prefix    = local.prefix
   env_short = local.env_short
   env       = local.env
-  domain    = local.domain
 
   repositories = [local.repo_name]
 

--- a/infra/repository/data.tf
+++ b/infra/repository/data.tf
@@ -1,9 +1,9 @@
 data "azurerm_user_assigned_identity" "identity_prod_ci" {
-  name                = "${local.project}-typescript-github-ci-identity"
+  name                = "${local.project}-github-ci-identity"
   resource_group_name = local.identity_resource_group_name
 }
 
 data "azurerm_user_assigned_identity" "identity_prod_cd" {
-  name                = "${local.project}-typescript-github-cd-identity"
+  name                = "${local.project}-github-cd-identity"
   resource_group_name = local.identity_resource_group_name
 }

--- a/infra/repository/locals.tf
+++ b/infra/repository/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  project = "dx-p"
+  project = "dxt-p"
 
   identity_resource_group_name = "${local.project}-identity-rg"
 


### PR DESCRIPTION
Switch from `dx-p-typescript` to `dxt` to do not overlap with the "official" repository