### PR TITLE
[DEVEX-108] Add PR workflow for Infrastructure

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -1,0 +1,162 @@
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment where the resources will be deployed.
+        type: string
+        required: true
+      region:
+        description: Azure region where the resources will be deployed.
+        type: string
+        required: true
+      env_vars:
+        description: List of environment variables to set up, given in env=value format.
+        type: string
+        required: false
+      use_private_agent:
+        description: Use a private agent to run the Terraform plan.
+        type: boolean
+        required: false
+        default: false
+
+env:
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_USE_OIDC: true
+  ARM_USE_AZUREAD: true
+  ARM_STORAGE_USE_AZUREAD: true
+
+jobs:
+  tf_plan:
+    name: 'Terraform Plan'
+    runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-20.04' }}
+    environment: ${{ inputs.environment }}-ci
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    env:
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+
+      # Set the directory where the Terraform files are located
+      # The directory the value is then available in ${{ steps.directory.outputs.dir }}
+      - name: Set directory
+        id: directory
+        run: |
+          set -e
+          if [ -z "${{ inputs.environment }}" ] || [ -z "${{ inputs.region }}" ]; then
+            echo "Both environment and region must be provided."
+            exit 1
+          else
+            # The directory is expected to be in the format 
+            #  infra/resources/${{ inputs.environment }}/${{ inputs.region }}
+            # Example: infra/resources/prod/westeurope
+            echo "dir=infra/resources/${{ inputs.environment }}/${{ inputs.region }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        name: Checkout
+
+      - name: Set Environment Variables
+        if: ${{ inputs.env_vars }}
+        run: |
+          for i in "${{ inputs.env_vars }}"
+          do
+            printf "%s\n" $i >> $GITHUB_ENV
+          done
+
+      - name: Azure Login
+        uses: azure/login@v2 # v2.0.0
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Set Terraform Version
+        id: set-terraform-version
+        run: |
+          echo "terraform_version=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        name: Setup Terraform
+        with:
+          terraform_version: ${{ steps.set-terraform-version.outputs.terraform_version }}
+
+      - name: Terraform Init
+        working-directory: ${{ steps.directory.outputs.dir }}
+        run: |
+          terraform init
+
+      # Run Terraform Plan
+      # The plan output is saved in a file and then processed to remove unnecessary lines
+      # The step never fails but the result is checked in the next step
+      # This is because we want to post the plan output in the PR even if the plan fails
+      - name: Terraform Plan
+        id: plan
+        working-directory: ${{ steps.directory.outputs.dir }}
+        run: |
+          set -e
+
+          echo "no output" > plan_output_multiline.txt
+          terraform plan -lock-timeout=3000s -no-color | tee plan_output.txt
+          OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
+          echo "$OUTPUT" > plan_output_multiline.txt
+
+          if [ $? -ne 0 ]; then
+            echo "result=failed" >> $GITHUB_OUTPUT
+          fi
+
+      # Post the plan output in the PR
+      # The plan output is posted in a comment in the PR
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        name: Post Plan on PR
+        if: success() && github.event_name == 'pull_request'
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('${{ steps.directory.outputs.dir }}/plan_output_multiline.txt', 'utf8');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Plan')
+            })
+            const commentBody = `#### Terraform Plan ('${{ steps.directory.outputs.dir }}') 📖
+            <details>
+            <summary>Terraform Plan</summary>
+
+            \`\`\`hcl
+            ${output}
+            \`\`\`
+
+            </details>
+            `;
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody,
+                comment_id: botComment.id
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody,
+                issue_number: context.issue.number
+              })
+            }
+
+      # Fail the workflow if the Terraform plan failed
+      - name: Check Terraform Plan Result
+        if: always()
+        run: |
+          if [ "${{ steps.plan.outputs.result }}" == "failed" ]; then
+            echo "::error::Terraform plan failed"
+            exit 1
+          fi

--- a/.github/workflows/pr_infra.yaml
+++ b/.github/workflows/pr_infra.yaml
@@ -1,0 +1,26 @@
+name: PR Infrastructure Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      # Trigger the workflow when resources are modified
+      - "infra/resources"
+      # Trigger the workflow when the involved workflows are modified
+      - ".github/workflows/pr_infra.yaml"
+      - ".github/workflows/templates/infra_**"
+
+jobs:
+  code_review_prod:
+    uses: ./.github/workflows/infra_plan.yaml
+    name: Code Review Infrastructure Plan
+    secrets: inherit
+    with:
+      environment: prod
+      region: westeurope

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Scaffold a new project using a monorepo structure.
 Each monorepo is meant to include all the published artifacts for the project as well as the infrastructure definition.
 
-## Requisites
+## Requirements
 
 - `Node.js` v20
 - `Terraform` v1.7.5

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Scaffold a new project using a monorepo structure.
 Each monorepo is meant to include all the published artifacts for the project as well as the infrastructure definition.
 
+## Requisites
+
+- `Node.js` v20
+- `Terraform` v1.7.5
+
 ## Tasks
 
 Tasks are defined in the `turbo.json` and `package.json` files. To execute a task, just run the command at the project root:
@@ -21,6 +26,7 @@ To define a new task:
 Defined tasks are _lint_, _test_, and _typecheck_.
 
 ## Dependencies
+
 ```sh
 # install all dependencies for the project
 yarn
@@ -61,6 +67,7 @@ Packages that are meant for internal code sharing have `private: true` in their 
 Each sub-folder is a workspace.
 
 ### `/infra`
+
 It contains the _infrastructure-as-code_ project that defines the resources for the project as well as the executuion environments. Database schemas and migrations are defined here too, in case they are needed.
 
 ### `/docs`
@@ -68,3 +75,68 @@ It contains the _infrastructure-as-code_ project that defines the resources for 
 Technical documentation about the project. Topics that may be included are architecture overviews, [ADRs](https://adr.github.io/), coding standards, and anything that can be relevant for a developer approaching the project as a contributor or as an auditor.
 
 User documentation doesn't usually go in here. For public packages, it must go in the package's `README` file so that it will also be uploaded to the registry; user-faced documentation websites, when needed by the project, go under the `/apps` folder as they are treated as end-user applications.
+
+## Infrastructure as Code
+
+### Folder structure
+
+The IaC template contains the following projects:
+
+#### identity
+
+Handle the identity federation between GitHub and Azure. The identity defines the grants the GitHub Workflows have on the Azure subscription.
+Configurations are intended for the pair (environment, region); each configuration is a Terraform project in the folder `infra/identity/<env>/<region>`
+It's intended to be executed once on a local machine at project initialization.
+
+⚠️ The following edits have to be done to work on the repository:
+
+- Define the project in the right env/region folder.
+- Edit `locals.tf` according to the intended configuration.
+- Edit `main.tf` with the actual Terraform state file location and name.
+
+```sh
+# Substitute env and region with actual values
+cd infra/identity/<env>/<region>
+
+# Substitute subscription_name with the actual subscription name
+az account set --name <subscription_name>
+
+terraform init
+terraform plan
+terraform apply
+```
+
+#### repository
+
+Set up the current repository settings.
+It's intended to be executed once on a local machine at project initialization.
+
+⚠️ The following edits have to be done to work on the repository:
+
+- Edit `locals.tf` according to the intended configuration.
+- Edit `main.tf` with the actual Terraform state file location and name.
+
+```sh
+cd infra/repository
+
+# Substitute subscription_name with the actual subscription name
+az account set --name <subscription_name>
+
+terraform init
+terraform plan
+terraform apply
+```
+
+#### resources
+
+Contains the actual resources for the developed applications.
+Configurations are intended for the pair (environment, region); each configuration is a Terraform project in the folder `infra/identity/<env>/<region>`
+
+⚠️ The following edits have to be done to work on the repository:
+
+- Edit `locals.tf` according to the intended configuration.
+- Edit `main.tf` with the actual Terraform state file location and name.
+
+### Workflow automation
+
+The workflow `pr_infra.yaml` is executed on every PR that edits the `infra/resources` folder or the workflow definition itself. It executes a `terraform plan` and comments the PR with the result. If the plan fails, the workflow fails.

--- a/docs/0004-we-use-folder-convention-for-infrastructure-resource-definitions.md
+++ b/docs/0004-we-use-folder-convention-for-infrastructure-resource-definitions.md
@@ -1,0 +1,55 @@
+# 1. We use folder convention for infrastructure resource definitions
+
+Date: 2024-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+Each monorepo holds the definition for infrastructure resources needed.
+
+## Decision
+
+The resource definitions will be placed into the `infra/resources` folder.
+Definitions are intended to work for an environment in a specific region. Each pair environment/region is a Terraform project on its own and they will be located in the `<env>/<region>` subfolder.
+
+Every automation will expect resources to be in such folders.
+
+#### Example
+
+```
+infra/
+├─ resource/
+│  ├─ _modules/
+│  │  ├─ azure-functions/
+│  │  │   ├─ main.tf
+│  │  │   ├─ outputs.tf
+│  │  │   ├─ inputs.tf
+│  │  ├─ resource-groups/
+│  │  │   ├─ main.tf
+│  │  │   ├─ outputs.tf
+│  │  │   ├─ inputs.tf
+│  ├─ dev/
+│  │  ├─ westeurope/
+│  │  │  ├─ main.tf
+│  ├─ prod/
+│  │  ├─ westeurope/
+│  │  │  ├─ main.tf
+│  │  ├─ northitaly/
+│  │  │  ├─ main.tf
+```
+
+In the example above, we define different resource sets:
+
+- production on west europe;
+- production on north italy;
+- development on west europe.
+
+An hypothetical use case might be that the applications are served to users from west europe, using north italy for redundancy on production; on development environment there is no need to high availability thus only west europe resources are defined.
+
+## Consequences
+
+- Each environment can define a different set of resources. This will allow scenarios such as partial test environments.
+- Applications that span over multiple regions require multiple Terraform projects

--- a/infra/resources/prod/westeurope/.terraform.lock.hcl
+++ b/infra/resources/prod/westeurope/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.98.0"
+  constraints = ">= 3.96.0"
+  hashes = [
+    "h1:3r3XaFLvWFiR16p1Qkfi67nygfUROO+vnV2X/UUs3mA=",
+    "h1:NgUpYK0Ym3DUtSORtakyJQsUEUtqBXIqe5bWs65oCvY=",
+    "h1:V/QrVROIPx2gZxFaQ4XHmdOvvNBHmghCk5Z1VSjl9/g=",
+    "h1:tVXTPKxCR3msOXWe17GaIZ9ZkI1NVhGanF4TklywSeo=",
+    "zh:012c79f671cff194d769ee53d50c56e7d353d4b78de8fceec9915bcf5955878b",
+    "zh:022d07683f84f8534fa40567860f76da6d15713d678cbc979c1d8cd502bb3246",
+    "zh:12cefd7df62c23c434d853e1824d421b4f18ff683540861376cf37138d70795b",
+    "zh:42626315686f504c59bec02745d7beff2bdfa732c3ecfaca7794f6641fbebfdc",
+    "zh:44708deec3fe13ea7cdd899ee766971fd024c06e2d8e189c30b59bd56ef3a5d3",
+    "zh:54a54fb4c8fc6537aae658503182e03af545e9151afe68da0f254d9b31037c63",
+    "zh:8265688742f6b532f06a3cd0bb14a891eb2277a834cf126f4b483b6de0a8d8fa",
+    "zh:97294d6e502e4e07e0cd8d2669a05d7e5d1f42da542ced299b5d4a3849e8736e",
+    "zh:bf4b48606c53db399f53b3880d94f70fc1701c72fde269472d8231f6dda5cf49",
+    "zh:c5a957d61e4c705e2c94d53c6fff579d5262137b2192562d0dfbbda374891717",
+    "zh:e2a8232f20f74602632b24d50c5c9d21741b0345560e4133bfb38e257d20fb77",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/resources/prod/westeurope/main.tf
+++ b/infra/resources/prod/westeurope/main.tf
@@ -1,0 +1,22 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.96.0"
+    }
+
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "terraform-state-rg"
+    storage_account_name = "tfproddx"
+    container_name       = "terraform-state"
+    key                  = "dx-typescript.resources.prod.westeurope.tfstate"
+  }
+}
+
+provider "azurerm" {
+  features {
+  }
+}


### PR DESCRIPTION
co-authored with @Krusty93 

Set a workflow that:
* is triggered when the definitions for the infrastructure resources are modified
* run terraform plan and fail accordingly

See https://github.com/pagopa/dx-typescript/blob/DEVEX-108--ci-tf-plan/docs/0004-we-use-folder-convention-for-infrastructure-resource-definitions.md for folder structure rationale