### PR TITLE
[DEVEX-108] Add optional parameter to PR infra workflow

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -12,7 +12,7 @@ on:
       base_path:
         description: The base path on which the script will look for Terraform projects
         type: string
-        required: false
+        required: true
       env_vars:
         description: List of environment variables to set up, given in env=value format.
         type: string

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -9,6 +9,11 @@ on:
         description: Azure region where the resources will be deployed.
         type: string
         required: true
+      tf_configuration_path:
+        description:
+        type: string
+        required: false
+        default: infra/resources
       env_vars:
         description: List of environment variables to set up, given in env=value format.
         type: string
@@ -51,10 +56,10 @@ jobs:
             echo "Both environment and region must be provided."
             exit 1
           else
-            # The directory is expected to be in the format 
+            # The directory is expected to be in the format
             #  infra/resources/${{ inputs.environment }}/${{ inputs.region }}
             # Example: infra/resources/prod/westeurope
-            echo "dir=infra/resources/${{ inputs.environment }}/${{ inputs.region }}" >> $GITHUB_OUTPUT
+            echo "dir=${{ inputs.tf_configuration_path}}/${{ inputs.environment }}/${{ inputs.region }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -9,11 +9,10 @@ on:
         description: Azure region where the resources will be deployed.
         type: string
         required: true
-      tf_configuration_path:
-        description:
+      base_path:
+        description: The base path on which the script will look for Terraform projects
         type: string
         required: false
-        default: infra/resources
       env_vars:
         description: List of environment variables to set up, given in env=value format.
         type: string
@@ -59,7 +58,7 @@ jobs:
             # The directory is expected to be in the format
             #  infra/resources/${{ inputs.environment }}/${{ inputs.region }}
             # Example: infra/resources/prod/westeurope
-            echo "dir=${{ inputs.tf_configuration_path}}/${{ inputs.environment }}/${{ inputs.region }}" >> $GITHUB_OUTPUT
+            echo "dir=${{ inputs.base_path}}/${{ inputs.environment }}/${{ inputs.region }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/pr_infra.yaml
+++ b/.github/workflows/pr_infra.yaml
@@ -24,3 +24,4 @@ jobs:
     with:
       environment: prod
       region: westeurope
+      base_path: infra/resources

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ terraform apply
 #### resources
 
 Contains the actual resources for the developed applications.
-Configurations are intended for the pair (environment, region); each configuration is a Terraform project in the folder `infra/identity/<env>/<region>`
+Configurations are intended for the pair (environment, region); each configuration is a Terraform project in the folder `infra/resources/<env>/<region>`
 
 ⚠️ The following edits have to be done to work on the repository:
 


### PR DESCRIPTION
Update `infra_plan.yaml` workflow template by adding an optional parameter to override the path where execute the code review.

It was previously hardcoded to `infra/resources`, but that path is not applicable to few repositories such as `io-infra`. For this reason, this PR adds an optional parameter `tf_configuration_path` to allow clients to set the path to the desired location