### PR TITLE
Fix pr_infra and release_infra workflows

### DIFF
--- a/.github/workflows/pr_infra.yaml
+++ b/.github/workflows/pr_infra.yaml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
       - reopened
       - ready_for_review

--- a/.github/workflows/pr_infra.yaml
+++ b/.github/workflows/pr_infra.yaml
@@ -11,7 +11,7 @@ on:
       - ready_for_review
     paths:
       # Trigger the workflow when resources are modified
-      - "infra/resources"
+      - "infra/resources/**"
       # Trigger the workflow when the involved workflows are modified
       - ".github/workflows/pr_infra.yaml"
       - ".github/workflows/templates/infra_**"

--- a/.github/workflows/release_infra.yml
+++ b/.github/workflows/release_infra.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       # Trigger the workflow when resources are modified
-      - "infra/resources"
+      - "infra/resources/**"
 
 jobs:
   release_prod:


### PR DESCRIPTION
## List of changes
- Fix `paths` value to trigger the workflow if any changes are detected on any files under the specified directory.
- Remove `edited` from the list of action types of the `pull_request` trigger
> [!NOTE]  
> The `edited` type means that changes on the title and/or description of the Pull Request triggers the action. In this case, I don't think it's convenient to execute the `terraform plan` operation on PR's description changes.
> Take a look at [GitHub official](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request) doc for more info.